### PR TITLE
Fix get length on strings containing fghijkl.  The asdfghjkl sequence…

### DIFF
--- a/length.go
+++ b/length.go
@@ -82,12 +82,24 @@ func getLength(password string) int {
 	password = removeMoreThanTwoRepeatingChars(password)
 	password = removeMoreThanTwoFromSequence(password, seqNums)
 	password = removeMoreThanTwoFromSequence(password, seqKeyboard0)
-	password = removeMoreThanTwoFromSequence(password, seqKeyboard1)
+	passwordSeq1First := removeMoreThanTwoFromSequence(password, seqKeyboard1)
+	passwordSeqAlphabetFirst := removeMoreThanTwoFromSequence(password, seqAlphabet)
+	// Depending on which order you run these in, you can get different length.
+	if len(passwordSeq1First) < len(passwordSeqAlphabetFirst) {
+		password = removeMoreThanTwoFromSequence(passwordSeq1First, seqAlphabet)
+	} else {
+		password = removeMoreThanTwoFromSequence(passwordSeqAlphabetFirst, seqKeyboard1)
+	}
 	password = removeMoreThanTwoFromSequence(password, seqKeyboard2)
-	password = removeMoreThanTwoFromSequence(password, seqAlphabet)
 	password = removeMoreThanTwoFromSequence(password, getReversedString(seqNums))
 	password = removeMoreThanTwoFromSequence(password, getReversedString(seqKeyboard0))
-	password = removeMoreThanTwoFromSequence(password, getReversedString(seqKeyboard1))
+	passwordSeq1First = removeMoreThanTwoFromSequence(password, getReversedString(seqKeyboard1))
+	passwordSeqAlphabetFirst = removeMoreThanTwoFromSequence(password, getReversedString(seqAlphabet))
+	if len(passwordSeq1First) < len(passwordSeqAlphabetFirst) {
+		password = removeMoreThanTwoFromSequence(passwordSeq1First, getReversedString(seqAlphabet))
+	} else {
+		password = removeMoreThanTwoFromSequence(passwordSeqAlphabetFirst, getReversedString(seqKeyboard1))
+	}
 	password = removeMoreThanTwoFromSequence(password, getReversedString(seqKeyboard2))
 	password = removeMoreThanTwoFromSequence(password, getReversedString(seqAlphabet))
 	return len(password)

--- a/length_test.go
+++ b/length_test.go
@@ -100,4 +100,16 @@ func TestGetLength(t *testing.T) {
 	if actual != expected {
 		t.Errorf("Wanted %v, got %v", expected, actual)
 	}
+
+	actual = getLength("abcdefghijkl123456")
+	expected = 4
+	if actual != expected {
+		t.Errorf("Wanted %v, got %v", expected, actual)
+	}
+
+	actual = getLength("asdfghjkl123456")
+	expected = 4
+	if actual != expected {
+		t.Errorf("Wanted %v, got %v", expected, actual)
+	}
 }


### PR DESCRIPTION
… was running first, resulting in a sequence like fgijk, which then would turn into fgij, when it should have turned into fg. Running seqAlphabet first avoids this issue, but then asdfghjkl gets the same issue.  To remedy,

we can run both and then see which one removed more characters.